### PR TITLE
fix: keep matrix background behind content

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -313,7 +313,7 @@ All colors MUST be HSL.
     height: 100%;
     pointer-events: none;
     overflow: hidden;
-    z-index: 1;
+    z-index: 0;
   }
 
   .matrix-char {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,29 +13,32 @@ const Index = () => {
     <div className="min-h-screen bg-background relative">
       {/* Matrix background effect */}
       <MatrixBackground />
-      {/* Hero Section - Above the Fold */}
-      <HeroSection />
-      
-      {/* Section 1: The Original Manhattan Project */}
-      <OriginalProject />
-      
-      {/* Section 2: The New Manhattan Project */}
-      <NewProject />
-      
-      {/* Section 3: What We're Building */}
-      <WhatWereBuilding />
-      
-      {/* Section 4: Feature Table */}
-      <FeatureTable />
-      
-      {/* Section 5: Demo */}
-      <DemoSection />
-      
-      {/* Section 6: Philosophy */}
-      <PhilosophySection />
-      
-      {/* Section 7: Call to Action */}
-      <CallToAction />
+      {/* Main content wrapper to sit above background */}
+      <div className="relative z-10">
+        {/* Hero Section - Above the Fold */}
+        <HeroSection />
+
+        {/* Section 1: The Original Manhattan Project */}
+        <OriginalProject />
+
+        {/* Section 2: The New Manhattan Project */}
+        <NewProject />
+
+        {/* Section 3: What We're Building */}
+        <WhatWereBuilding />
+
+        {/* Section 4: Feature Table */}
+        <FeatureTable />
+
+        {/* Section 5: Demo */}
+        <DemoSection />
+
+        {/* Section 6: Philosophy */}
+        <PhilosophySection />
+
+        {/* Section 7: Call to Action */}
+        <CallToAction />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- ensure matrix rain effect renders behind the page content
- wrap main sections in a high z-index container for proper stacking

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_688e4b6d79788322bd59103f98f8d895