### PR TITLE
fix: keep matrix background behind content

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/index.css
+++ b/src/index.css
@@ -313,7 +313,7 @@ All colors MUST be HSL.
     height: 100%;
     pointer-events: none;
     overflow: hidden;
-    z-index: 1;
+    z-index: -1;
   }
 
   .matrix-char {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,29 +13,32 @@ const Index = () => {
     <div className="min-h-screen bg-background relative">
       {/* Matrix background effect */}
       <MatrixBackground />
-      {/* Hero Section - Above the Fold */}
-      <HeroSection />
-      
-      {/* Section 1: The Original Manhattan Project */}
-      <OriginalProject />
-      
-      {/* Section 2: The New Manhattan Project */}
-      <NewProject />
-      
-      {/* Section 3: What We're Building */}
-      <WhatWereBuilding />
-      
-      {/* Section 4: Feature Table */}
-      <FeatureTable />
-      
-      {/* Section 5: Demo */}
-      <DemoSection />
-      
-      {/* Section 6: Philosophy */}
-      <PhilosophySection />
-      
-      {/* Section 7: Call to Action */}
-      <CallToAction />
+      {/* Main content wrapper to sit above background */}
+      <div className="relative z-10">
+        {/* Hero Section - Above the Fold */}
+        <HeroSection />
+
+        {/* Section 1: The Original Manhattan Project */}
+        <OriginalProject />
+
+        {/* Section 2: The New Manhattan Project */}
+        <NewProject />
+
+        {/* Section 3: What We're Building */}
+        <WhatWereBuilding />
+
+        {/* Section 4: Feature Table */}
+        <FeatureTable />
+
+        {/* Section 5: Demo */}
+        <DemoSection />
+
+        {/* Section 6: Philosophy */}
+        <PhilosophySection />
+
+        {/* Section 7: Call to Action */}
+        <CallToAction />
+      </div>
     </div>
   );
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -109,5 +110,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- ensure matrix rain effect renders behind the page content with a negative z-index
- replace empty interface declarations with type aliases for lint compliance
- switch tailwindcss-animate plugin to ESM import

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688e4b6d79788322bd59103f98f8d895