### PR TITLE
fix: enable CTA button clicks

### DIFF
--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -112,7 +112,7 @@ export const CallToAction = () => {
       </div>
 
       {/* Neural Background Pattern */}
-      <div className="absolute inset-0 neural-grid opacity-5" />
+      <div className="absolute inset-0 neural-grid opacity-5 pointer-events-none" />
       
       {/* Atomic Glow */}
       <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-gradient-neural opacity-10 rounded-full blur-3xl pointer-events-none" />


### PR DESCRIPTION
## Summary
- prevent background overlay from intercepting clicks so CTA buttons work

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden; An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_688faa88e2608322a3fa6471462d7357